### PR TITLE
fix(setup): eliminate double-run requirement for swap-scenario.sh

### DIFF
--- a/scripts/swap-scenario.sh
+++ b/scripts/swap-scenario.sh
@@ -75,15 +75,21 @@ echo ""
 
 cd "$TF_DIR"
 info "Running terraform apply..."
-terraform apply -var-file="$TFVARS_FILE" -auto-approve
+APPLY_EXIT=0
+terraform apply -var-file="$TFVARS_FILE" -auto-approve 2>&1 || APPLY_EXIT=$?
 
-# Detect provider-caused drift (guardrail_configuration null bug)
-info "Verifying configuration convergence..."
-PLAN_EXIT=0
-terraform plan -var-file="$TFVARS_FILE" -detailed-exitcode -out=/dev/null >/dev/null 2>&1 || PLAN_EXIT=$?
-if [ "$PLAN_EXIT" -eq 2 ]; then
-  warn "Detected configuration drift (known provider issue). Running corrective apply..."
+if [ "$APPLY_EXIT" -ne 0 ]; then
+  warn "Initial apply exited with code $APPLY_EXIT (likely provider inconsistency bug). Retrying..."
   terraform apply -var-file="$TFVARS_FILE" -auto-approve
+else
+  # Detect provider-caused drift (guardrail_configuration null bug)
+  info "Verifying configuration convergence..."
+  PLAN_EXIT=0
+  terraform plan -var-file="$TFVARS_FILE" -detailed-exitcode -out=/dev/null >/dev/null 2>&1 || PLAN_EXIT=$?
+  if [ "$PLAN_EXIT" -eq 2 ]; then
+    warn "Detected configuration drift (known provider issue). Running corrective apply..."
+    terraform apply -var-file="$TFVARS_FILE" -auto-approve
+  fi
 fi
 
 echo ""

--- a/scripts/swap-scenario.sh
+++ b/scripts/swap-scenario.sh
@@ -77,6 +77,15 @@ cd "$TF_DIR"
 info "Running terraform apply..."
 terraform apply -var-file="$TFVARS_FILE" -auto-approve
 
+# Detect provider-caused drift (guardrail_configuration null bug)
+info "Verifying configuration convergence..."
+PLAN_EXIT=0
+terraform plan -var-file="$TFVARS_FILE" -detailed-exitcode -out=/dev/null >/dev/null 2>&1 || PLAN_EXIT=$?
+if [ "$PLAN_EXIT" -eq 2 ]; then
+  warn "Detected configuration drift (known provider issue). Running corrective apply..."
+  terraform apply -var-file="$TFVARS_FILE" -auto-approve
+fi
+
 echo ""
 success "Scenario '${SCENARIO}' is now active."
 

--- a/terraform/modules/agent/main.tf
+++ b/terraform/modules/agent/main.tf
@@ -223,6 +223,10 @@ resource "null_resource" "prepare_agent" {
     foundation_model       = var.foundation_model
     guardrail_version      = var.guardrail_version
     use_weak_system_prompt = var.use_weak_system_prompt
+    # Previously missing — these change the agent config but didn't trigger re-preparation
+    enable_refund_confirmation = var.enable_refund_confirmation
+    instruction_hash           = sha256(local.system_prompt)
+    api_schema_hash            = sha256(aws_bedrockagent_agent_action_group.customer_tools.api_schema[0].payload)
   }
 
   depends_on = [


### PR DESCRIPTION
## Summary

- **Add missing triggers** to `null_resource.prepare_agent` in `terraform/modules/agent/main.tf`: `enable_refund_confirmation`, `instruction_hash` (sha256 of system prompt), and `api_schema_hash` (sha256 of OpenAPI spec). These ensure agent re-preparation fires whenever scenario-changing inputs are modified.
- **Add post-apply drift detection** to `scripts/swap-scenario.sh`: after `terraform apply`, runs `terraform plan -detailed-exitcode` to catch the known provider bug where `guardrail_configuration` reads back as null. If drift is detected (exit code 2), automatically runs a corrective apply.

Closes #21

## Test plan

- [ ] Deploy secure-baseline: `./scripts/swap-scenario.sh secure-baseline`
- [ ] Switch scenario: `./scripts/swap-scenario.sh scenario-tool-manipulation`
- [ ] Verify agent responds correctly in a single run (no second run needed)
- [ ] If corrective apply fires, confirm "Detected configuration drift" warning appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)